### PR TITLE
Changed amount on readme from number to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ const payment_tx = async () => {
       customer_email: 'kalunjoku123@gmail.com',
       coin: 'BUSD', // BUSD, DAI, USDC or USDT
       currency: 'USD', // NGN, AED, GBP, EUR
-      amount: 100,
+      amount: '100',
       accept_partial_payment: true, // By default it's false
       metadata: { 
         type: "Wallet fund"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the readme document code for initializing payment. the amount on the payload passes the figure as a number instead of a string
## Motivation and Context
lazerpay.Payment.initializePayment(transactionpayload)

the function above currently accepts amount in strings not data 
